### PR TITLE
Use ssl_certificate_file basename as destination

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Copy SSL key and cert for logstash-forwarder.
   copy:
     src: "{{ logstash_forwarder_ssl_certificate_file }}"
-    dest: "{{ logstash_ssl_dir }}/{{ logstash_forwarder_ssl_certificate_file }}"
+    dest: "{{ logstash_ssl_dir }}/{{ logstash_forwarder_ssl_certificate_file | basename }}"
     mode: 0644
   notify: restart logstash-forwarder
 

--- a/templates/logstash-forwarder.j2
+++ b/templates/logstash-forwarder.j2
@@ -2,7 +2,7 @@
   "network": {
     "servers": [ "{{ logstash_forwarder_logstash_server }}:{{ logstash_forwarder_logstash_server_port }}" ],
     "timeout": 15,
-    "ssl ca": "{{ logstash_ssl_dir }}/{{ logstash_forwarder_ssl_certificate_file }}"
+    "ssl ca": "{{ logstash_ssl_dir }}/{{ logstash_forwarder_ssl_certificate_file | basename }}"
   },
   "files": {{ logstash_forwarder_files | to_json }}
 }


### PR DESCRIPTION
Usefull when specifying a full or relative path to some certificate in your ansible repo.
